### PR TITLE
Make decoding faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/Makefile
+/Makefile.old
+/MYMETA.*
+/blib/
+/pm_to_blib


### PR DESCRIPTION
The specific test case is a list of relatively small blobs, can be
generating by encoding

    my $data = [
        map {
            "X" . (chr(rand(64) + 32) x 1676)
        } (1 .. 2000)
    ];
    
decoding time goes from ~1.5s to ~0.003s
